### PR TITLE
Install target for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ obj-m += usb_8dev.o
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
 
+install:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules_install
+
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 


### PR DESCRIPTION
This adds an install target to the pre-3.3 Makefile. Probably useful for post-3.3. too.
